### PR TITLE
dst-file must be truncated before writing new data

### DIFF
--- a/main.go
+++ b/main.go
@@ -76,7 +76,7 @@ func main() {
 		dst = os.Stdout
 	} else {
 		var err error
-		dst, err = os.OpenFile(*destination, os.O_RDWR|os.O_CREATE, 0755)
+		dst, err = os.OpenFile(*destination, os.O_RDWR|os.O_CREATE|O_TRUNC, 0755)
 		if err != nil {
 			panic(err.Error())
 		}


### PR DESCRIPTION
dst-file must be truncated. Otherwise the data may be inconsistent if the file was larger before overwriting.