### PR TITLE
Skip ipv6 addresses from dump

### DIFF
--- a/main.go
+++ b/main.go
@@ -64,7 +64,7 @@ func main() {
 		AutoAggregate(nets, aaSettings)
 		nets = PackNETs(nets)
 		if *logStatistic {
-			log.Printf("After auto aggregate: %v networks/IPs with %v IPs coverage. Removed %.2v%% records (%v). Add %.2v%% IPs coverage (%v).\n", len(nets), nets.Count(), float32(netsL-len(nets))*100/float32(netsL), netsL-len(nets), float32(nets.Count()-netsC)*100/float32(netsC), nets.Count()-netsC)
+			log.Printf("After auto aggregate: %v networks/IPs with %v IPs coverage. Removed %.2v%% records (%v). Add %.2f%% IPs coverage (%v).\n", len(nets), nets.Count(), float32(netsL-len(nets))*100/float32(netsL), netsL-len(nets), float32(nets.Count()-netsC)*100/float32(netsC), nets.Count()-netsC)
 		}
 	}
 


### PR DESCRIPTION
Now z-i dump.csv contains ipv6 adresses as well as ipv4 ones.
I propose just to skip them to prevent error messages and keep working with ipv4.